### PR TITLE
Add TypeScript support for api.require and custom middleware

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,8 +36,8 @@ export declare interface App {
   [namespace: string]: HandlerFunction;
 }
 
-export declare type Middleware = (req: Request, res: Response, next: Middleware | NextFunction) => void;
-export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware | NextFunction) => void;
+export declare type Middleware = (req: Request, res: Response, next: NextFunction) => void;
+export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: NextFunction) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type RoutingFunction = (api: API, opts?: object) => void;
 export declare type HandlerFunction = (req?: Request, res?: Response, next?: NextFunction) => void | {} | Promise<{}>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export declare interface App {
 export declare type Middleware = (req: Request, res: Response, next: Middleware) => void;
 export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware) => void;
 export declare type ErrorCallback = (error?: Error) => void;
+export declare type RoutingFunction = (api: API, opts?: object) => void;
 export declare type HandlerFunction = (req?: Request, res?: Response, next?: NextFunction) => void | {} | Promise<{}>;
 export declare type LoggerFunction = (message: string) => void;
 export declare type NextFunction = () => void;
@@ -94,6 +95,18 @@ export declare interface Options {
   };
   serializer?: SerializerFunction;
   version?: string;
+}
+
+export declare interface RegisterOptions extends Options {
+  prefix?: string;
+}
+
+export declare interface Route {
+  vars: {[key: string]: string};
+  stack: HandlerFunction[];
+  inherited?: HandlerFunction[];
+  route: string;
+  path: string;
 }
 
 export declare class Request {
@@ -203,6 +216,8 @@ export declare class API {
   use (...errorHandlingMiddleware: ErrorHandlingMiddleware[]);
 
   finally(callback: FinallyFunction): void;
+  
+  register(fn: RoutingFunction, opts?: RegisterOptions): void;
 
   run(event: APIGatewayEvent, context: Context, cb: (err: Error, result: any) => void): void;
   run(event: APIGatewayEvent, context: Context): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,8 +36,8 @@ export declare interface App {
   [namespace: string]: HandlerFunction;
 }
 
-export declare type Middleware = (req: Request, res: Response, next: Middleware) => void;
-export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware) => void;
+export declare type Middleware = (req: Request, res: Response, next: Middleware | NextFunction) => void;
+export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware | NextFunction) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type RoutingFunction = (api: API, opts?: object) => void;
 export declare type HandlerFunction = (req?: Request, res?: Response, next?: NextFunction) => void | {} | Promise<{}>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,8 +36,8 @@ export declare interface App {
   [namespace: string]: HandlerFunction;
 }
 
-export declare type Middleware = (req?: Request, res?: Response, next?: Middleware) => void;
-export declare type ErrorHandlingMiddleware = (error?: Error, req: Request?, res: Response?, next: ErrorHandlingMiddleware) => void;
+export declare type Middleware = (req: Request, res: Response, next: Middleware) => void;
+export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type RoutingFunction = (api: API, opts?: object) => void;
 export declare type HandlerFunction = (req?: Request, res?: Response, next?: NextFunction) => void | {} | Promise<{}>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,8 +36,8 @@ export declare interface App {
   [namespace: string]: HandlerFunction;
 }
 
-export declare type Middleware = (req: Request, res: Response, next: Middleware) => void;
-export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware) => void;
+export declare type Middleware = (req?: Request, res?: Response, next?: Middleware) => void;
+export declare type ErrorHandlingMiddleware = (error?: Error, req: Request?, res: Response?, next: ErrorHandlingMiddleware) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type RoutingFunction = (api: API, opts?: object) => void;
 export declare type HandlerFunction = (req?: Request, res?: Response, next?: NextFunction) => void | {} | Promise<{}>;


### PR DESCRIPTION
I ran into a TypeScript error while trying to write a custom middleware:

```ts
import { Middleware, Request, Response } from 'lambda-api'

const myMiddleware: Middleware = (req: Request, res: Response, next: Middleware) => {
  console.log(req)
  next() // Expected 3 arguments, but got 0
}

export default myMiddleware
```

My PR fixes this by making the arguments in `Middleware` optional.

And I needed TS support for require so I added it.